### PR TITLE
sample on raf

### DIFF
--- a/sample/main.ts
+++ b/sample/main.ts
@@ -10,8 +10,8 @@ import isolate from '@cycle/isolate';
 import { Component as SubComponent } from './widget';
 function Component ({Sandbox, ...sources}: Sources & {Sandbox: any} ): Sinks {
   const sub = SubComponent(sources);
-  const vdom$ = periodic(1000)
-    .startWith(null)
+  const vdom$ = 
+    just(null)
     .map(() => combineArray(
       (...children) => h('div', {}, children as Array<VNode>),
       Array(4).fill(null).map(() => Sandbox.select(

--- a/src/dom/worker.ts
+++ b/src/dom/worker.ts
@@ -3,6 +3,7 @@ import { default as xs, Stream, Subscription} from 'xstream';
 import { VNode, h } from '@cycle/dom';
 import * as uuid from 'uuid/v4';
 import fromEvent from 'xstream/extra/fromevent';
+import sampleCombine from 'xstream/extra/samplecombine';
 
 import {
   adapt
@@ -16,13 +17,17 @@ import {
   WorkerDOMEvent
 } from './main';
 
+import { 
+  SandboxMessageCommand
+} from '../main'
+
 export const DOMWorkerConnector: WorkerConnector = (rx, tx) => {
   rx.start();
   tx.start();
   return (sink$: Stream<VNode>): any => {
-    
-    sink$.subscribe({
-      next (vnode) {
+    const raf$ = fromEvent(self, 'message').filter(e => e.data.cmd === SandboxMessageCommand.raf);
+    raf$.compose(sampleCombine(sink$)).subscribe({
+      next ([_, vnode]) {
         const message: WorkerDOMMessage = {
           cmd: WorkerDOMMessageCommand.vnode,
           payload: vnode

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,17 +68,21 @@ export function portMap(channels: MessageChannels, portNumber: 1 | 2): MessagePo
 export function makeSandboxDriver(): Driver<undefined, Sources> {
 
 
+  let raf: boolean;
   
   const raf$ = xs.create({
     start(listener) {
+      raf = true;
       const r = () => requestAnimationFrame((e) => {
         listener.next(e);
-        r();
+        if (raf) {
+          raf;
+        }
       });
       r();
     },
     stop() {
-
+      raf = false;
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ export function makeSandboxDriver(): Driver<undefined, Sources> {
       const r = () => requestAnimationFrame((e) => {
         listener.next(e);
         if (raf) {
-          raf;
+          r();
         }
       });
       r();


### PR DESCRIPTION
samle the returning DOM stream with RAF from main thread.
This is to avoid DOM updates queuing up, when the window is idle, and replaying upon focus.
#11 